### PR TITLE
use new image service

### DIFF
--- a/main.js
+++ b/main.js
@@ -40,7 +40,7 @@ function fetchData () {
 				cachedNames = [];
 				if (cachedTeam) {
 					cachedTeam.forEach((obj) => {
-						obj.headshotUrl = `http://image.webservices.ft.com/v1/images/raw/fthead:${obj.slug}?source=alphaville`;
+						obj.headshotUrl = `https://www.ft.com/__origami/service/image/v2/images/raw/fthead:${obj.slug}?source=alphaville`;
 
 						cachedNames.push({
 							name: obj.title,


### PR DESCRIPTION
We launched the new image service 6 days ago, I'm currently going around FT projects and helping them migrate to it.

The new Image Service includes a lot of improvements:
- The application is multi-region with failover
- We use stale-on-error and stale-while-revalidate cache extensions to ensure users get stale content if the application errors or has to revalidate an image
- We serve much smaller WebP and JPEG XR images to supported browsers
- We’ve seen a reduction in file size for a large number of image requests
- We’re now serving images over H2